### PR TITLE
Allow python3 from multiple locations

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -68,9 +68,10 @@
 				<key>runningsubtext</key>
 				<string>Searching...</string>
 				<key>script</key>
-				<string>/opt/homebrew/bin/python3 app.py {query}</string>
+				<string>export PATH="/opt/homebrew/bin:/usr/local/bin:${PATH}"
+python3 app.py "${1}"</string>
 				<key>scriptargtype</key>
-				<integer>0</integer>
+				<integer>1</integer>
 				<key>scriptfile</key>
 				<string></string>
 				<key>subtext</key>


### PR DESCRIPTION
In its current iteration, the Workflow’s code is focused on people on Apple Silicon who have installed Python 3 with Homebrew. With this small notification, it will work too for people on Intel Macs and people who don’t have Homebrew installed (assuming the Workflow is compatible with Python 3.8.9).

It also changes it to `with input as argv`, which is more robust than `with input as {query}`.