### PR TITLE
fix: login by get method is unsafe

### DIFF
--- a/synology_api/auth.py
+++ b/synology_api/auth.py
@@ -39,7 +39,7 @@ class Authentication:
                 if self._debug is True:
                     return 'User already logged'
         else:
-            session_request = requests.get(
+            session_request = requests.post(
                 self._base_url + login_api, param, verify=self._verify)
             self._sid = session_request.json()['data']['sid']
             self._session_expire = False

--- a/synology_api/universal_search.py
+++ b/synology_api/universal_search.py
@@ -43,4 +43,4 @@ class UniversalSearch:
             "version": 1
         }
 
-        return self.request_data(api_name, api_path, req_param)
+        return self.request_data(api_name, api_path, req_param, method='post')


### PR DESCRIPTION
![Screen Shot 2023-02-05 at 22 34 58](https://user-images.githubusercontent.com/9097390/216826813-4f22fe22-cda5-4dc7-9ceb-b33af2aa4695.png)

The api of Synology DSM supports POST method . Modifying them to POST method gives much security ： 

![Screen Shot 2023-02-05 at 22 53 35](https://user-images.githubusercontent.com/9097390/216826729-6972ae8d-6a15-4656-a074-a5d5e55f2d69.png)
